### PR TITLE
Add CMakeLists.txt for building the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+# This CMakeLists.txt file builds this project.
+
+# Specify the minimum CMake version required
+cmake_minimum_required(VERSION 3.10)
+
+# Set the project name
+project(BilliardAnalysis)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find OpenCV package
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+# Collect all source files
+file(GLOB_RECURSE SOURCE_FILES "${PROJECT_SOURCE_DIR}/src/*.cpp")
+
+# Add executable target
+add_executable(BilliardAnalysis main.cpp ball_detection.cpp field_detection.cpp segmentation.cpp visualization.cpp evaluation.cpp output_data.cpp)
+
+# Link OpenCV libraries
+target_link_libraries(BilliardAnalysis ${OpenCV_LIBS})


### PR DESCRIPTION
This commit adds the CMakeLists.txt file to the project, which is used to build the project using CMake. The file sets the minimum required CMake version, specifies the project name, sets the C++ standard to C++11, finds the OpenCV package, collects all source and header files in the 'src' directory, adds an executable target, and links the OpenCV libraries to the target.

With this file, users can build the project using CMake by running the following commands in the project root directory:

mkdir build
cd build
cmake ..
cmake --build .

This will create a 'build' directory, configure the project using CMake, and build the executable target.